### PR TITLE
Implement new prefixing behavior

### DIFF
--- a/lib/uri.dart
+++ b/lib/uri.dart
@@ -4,9 +4,9 @@
 
 library uri;
 
-import 'package:quiver/collection.dart';
-import 'package:quiver/core.dart';
-import 'package:quiver/pattern.dart';
+import 'package:quiver/collection.dart' show mapsEqual;
+import 'package:quiver/core.dart' show firstNonNull, hash4;
+import 'package:quiver/pattern.dart' show escapeRegex;
 
 import 'src/encoding.dart';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: uri
-version: 0.7.1
+version: 0.8.0
 author: Dart Authors <misc@dartlang.org>
 description: Utilities for building and parsing URIs
 homepage: https://github.com/dart-lang/uri

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -12,10 +12,13 @@ import 'uri_template_test.dart' as template;
 import 'uri_test.dart' as uri;
 
 main() {
+  // Attempt to set the working directory to the project directory so that
+  // the spec tests, which access files, run correctly.
   var cwd = path.split(Directory.current.path);
   if (cwd.last == 'test') {
     Directory.current = path.joinAll(cwd.sublist(0, cwd.length - 1));
   }
+
   encoding.main();
   parser.main();
   spec.main();

--- a/test/uri_test.dart
+++ b/test/uri_test.dart
@@ -66,4 +66,5 @@ class TestUriPattern extends UriPattern {
   TestUriPattern(this.hashCode);
   UriMatch match(Uri uri) => null;
   bool operator ==(o) => hashCode == o.hashCode;
+  Uri expand(variables) => null;
 }


### PR DESCRIPTION
This adds the proposed new prefixing behavior. URI paths always use prefix patching, while fragments use prefix matching if the URI contains the separator characters '/' or '.'

I have not yet added the option to turn off prefix matching in the UriPattern constructor.
