### PR TITLE
increase upper bound quiver dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,6 @@ homepage: https://github.com/google/uri.dart
 environment:
   sdk: '>=0.8.10'
 dependencies:
-  quiver: '>=0.18.2 <0.19.0'
-  unittest: '>=0.9.2<=0.11.0'
-  utf: '>=0.8.10<=0.10.0'
+  quiver: '>=0.17.0 <0.19.0'
+  unittest: '>=0.9.2 <=0.11.0'
+  utf: '>=0.8.10 <=0.10.0'


### PR DESCRIPTION
Please release as I currently have a dependency version problem with quiver.

Note: all tests pass with quiver 0.18.2
