### PR TITLE
Widen quiver dependency range for DDC compilation compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=1.12.0'
 dependencies:
   matcher: '>=0.12.0 <0.13.0'
-  quiver: '>=0.17.0 <0.25.0'
+  quiver: '>=0.17.0 <0.26.0'
   utf: '>=0.8.10 <=0.10.0'
 dev_dependencies:
   test: '>=0.12.0 <=0.13.0'


### PR DESCRIPTION
### Problem
The current quiver dependency range (`'>=0.17.0 <0.22.0'`) is prohibitive for consumers trying to utilize strong-mode / DDC features.

### Solution
Widen the range to include quiver `0.25.0`.

> Once released / _published to pub_, these changes will address #25

---

@justinfagnani @sethladd @kevmoo