### PR TITLE
Fix apptreesoftware/flutter_google_map_view#17

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=1.12.0'
 dependencies:
   matcher: '>=0.12.0 <0.13.0'
-  quiver: '>=0.17.0 <0.26.2'
+  quiver: '>=0.17.0 <=0.26.2'
   utf: '>=0.8.10 <=0.10.0'
 dev_dependencies:
   test: '>=0.12.0 <=0.13.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=1.12.0'
 dependencies:
   matcher: '>=0.12.0 <0.13.0'
-  quiver: '>=0.17.0 <0.26.0'
+  quiver: '>=0.17.0 <0.26.2'
   utf: '>=0.8.10 <=0.10.0'
 dev_dependencies:
   test: '>=0.12.0 <=0.13.0'


### PR DESCRIPTION
This fixes the said issue according to [this](https://github.com/apptreesoftware/flutter_google_map_view/issues/13#issuecomment-365197096). There's a package version conflict between flutter_google_map_view and Flutter Test SDK ([source](https://github.com/apptreesoftware/flutter_google_map_view/issues/13#issuecomment-356180112)) so the workaround is to remove Flutter Test SDK from ``dev_dependencies``.