### PR TITLE
Expose path, query and fragment variables to UriParser users

### DIFF
--- a/lib/src/uri_template.dart
+++ b/lib/src/uri_template.dart
@@ -57,6 +57,12 @@ class UriParser extends UriPattern {
 
   RegExp? get pathRegex => _pathRegex;
 
+  List<String> get pathVariables => List.unmodifiable(_pathVariables);
+
+  Map<String, String?> get queryVariables => Map.unmodifiable(_queryVariables);
+
+  List<String> get fragmentVariables => List.unmodifiable(_fragmentVariables);
+
   UriParser(
     this.template, {
     bool fragmentPrefixMatching = true,


### PR DESCRIPTION
The idea is to expose the variables obtained by the UriParser which could be useful information if working with templates which are not known beforehand