### PR TITLE
Require Dart 2.17, update lints, enable analysis language modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [2.12.0, dev]
+        sdk: [2.17.0, dev]
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: dart-lang/setup-dart@v1.0
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [2.12.0, dev]
+        sdk: [2.17.0, dev]
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1-wip
+
+- Require Dart 2.17 or greater.
+
 ## 1.0.0
 
 - Enable null safety for this package.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,8 +1,10 @@
 include: package:lints/recommended.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
 
 linter:
   rules:
@@ -26,7 +28,6 @@ linter:
     - prefer_const_declarations
     - prefer_expression_function_bodies
     - prefer_final_locals
-    - prefer_interpolation_to_compose_strings
     - prefer_relative_imports
     - prefer_single_quotes
     - sort_pub_dependencies
@@ -35,7 +36,6 @@ linter:
     - type_annotate_public_apis
     - unawaited_futures
     - unnecessary_lambdas
-    - unnecessary_null_aware_assignments
     - unnecessary_parenthesis
     - unnecessary_statements
     - use_is_even_rather_than_modulo

--- a/lib/src/uri_template.dart
+++ b/lib/src/uri_template.dart
@@ -212,15 +212,15 @@ class UriParser extends UriPattern {
 /// See the RFC for more details.
 class UriTemplate {
   final String template;
-  final List _parts;
+  final List<Object> _parts;
 
   UriTemplate(this.template) : _parts = _compile(template);
 
   @override
   String toString() => template;
 
-  static UnmodifiableListView _compile(String template) {
-    final parts = [];
+  static UnmodifiableListView<Object> _compile(String template) {
+    final parts = <Object>[];
     template.splitMapJoin(
       _exprRegex,
       onMatch: (match) {
@@ -349,7 +349,7 @@ class UriTemplate {
  * over to the next _compileX method.
  */
 class _Compiler {
-  final Iterator _parts;
+  final Iterator<Object> _parts;
 
   RegExp? pathRegex;
   final List<String> pathVariables = [];
@@ -412,7 +412,7 @@ class _Compiler {
     }
   }
 
-  void _compileQuery({Match? match, List? prevParts}) {
+  void _compileQuery({Match? match, List<Object>? prevParts}) {
     void handleExpressionMatch(Match match) {
       final expr = match.group(3)!;
       for (var q in expr.split(',')) {
@@ -422,7 +422,7 @@ class _Compiler {
       }
     }
 
-    void handleLiteralParts(List literalParts) {
+    void handleLiteralParts(List<Object> literalParts) {
       for (var i = 0; i < literalParts.length; i++) {
         final subpart = literalParts[i];
         if (subpart is String) {
@@ -464,7 +464,7 @@ class _Compiler {
     }
   }
 
-  void _compileFragment({Match? match, List? prevParts}) {
+  void _compileFragment({Match? match, List<Object>? prevParts}) {
     final fragmentBuffer = StringBuffer();
 
     void handleExpressionMatch(Match match) {
@@ -537,8 +537,8 @@ Map<String, String> _parseMap(String s, String separator) {
   return map;
 }
 
-List _splitLiteral(String literal) {
-  final subparts = [];
+List<Object> _splitLiteral(String literal) {
+  final subparts = <Object>[];
   literal.splitMapJoin(
     _fragmentOrQueryRegex,
     onMatch: (m) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,16 @@
 name: uri
-version: 1.0.1-dev
+version: 1.0.1-wip
 description: >-
   Utilities for building and parsing URIs, including support for parsing
   URI templates as defined in RFC 6570.
 repository: https://github.com/google/uri.dart
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.17.0 <3.0.0'
 
 dependencies:
   matcher: ^0.12.10
   quiver: ^3.0.0
 
 dev_dependencies:
-  lints: ^1.0.0
+  lints: ^2.1.1
   test: ^1.16.0

--- a/test/spec_test.dart
+++ b/test/spec_test.dart
@@ -10,17 +10,18 @@ import 'dart:io';
 import 'package:test/test.dart';
 import 'package:uri/uri.dart';
 
-void runSpecTests(String testname, {String? solo}) {
-  final testFile = File('test/uritemplate-test/$testname.json');
-  final testJson = json.decode(testFile.readAsStringSync());
+void runSpecTests(String testName, {String? solo}) {
+  final testFile = File('test/uritemplate-test/$testName.json');
+  final testJson =
+      json.decode(testFile.readAsStringSync()) as Map<String, Object?>;
 
   for (var specGroup in testJson.keys) {
     group(specGroup, () {
-      final data = testJson[specGroup];
+      final data = testJson[specGroup] as Map<String, Object?>;
       final variables = data['variables'] as Map<String, Object?>;
       final testCases = data['testcases'] as List;
 
-      for (var testCase in testCases.cast<List>()) {
+      for (var testCase in testCases.cast<List<Object?>>()) {
         final templateString = testCase[0] as String;
         if (solo != null && templateString == solo) continue;
         test(templateString, () {


### PR DESCRIPTION
I'm trying to remove usages of the deprecated strong-mode options. This PR does so and enables the newer [analysis language modes](https://dart.dev/guides/language/analysis-options#enabling-additional-type-checks) as replacements. It also updates `package:lints` at the same time.

Removal issue reference: https://github.com/dart-lang/sdk/issues/50679