### PR TITLE
Update example in README file and also add it to `example` directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ UriMatch is the result of `UriPattern.match()`. It contains the parameters parse
 UriTemplate is an implementation of [RFC 6570 URI Templates][rfc6570]. URI Templates are useful for generating URIs from data. UriTemplates are created from a template string, and then expanded with data to generate a URI:
 
 ```dart
-var template = UriTemplate("http://example.com/~{user}/");
-String fredUri = template.expand({'user': 'fred'});
+final template = UriTemplate('http://example.com/~{user}/');
+final fredUri = template.expand({'user': 'fred'});
 print(fredUri); // prints: http://example.com/~fred/
 ```
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:uri/uri.dart';
+
+void main() {
+  final template = UriTemplate('http://example.com/~{user}/');
+  final fredUri = template.expand({'user': 'fred'});
+  print(fredUri); // prints: http://example.com/~fred/
+}


### PR DESCRIPTION
This PR applies some minor code style improvements to the example in the README file and also copies it over to the `example` directory to be more in line with `pub.dev` best practices and to resolve #31.